### PR TITLE
fix deprecated Command:args()

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -2,7 +2,7 @@ local M = {}
 
 function M:peek(job)
 	local child = Command("rich")
-		:args({
+		:arg({
 			"-j",
 			"--left",
 			"--line-numbers",


### PR DESCRIPTION
> Command:args() is deprecated. https://github.com/sxyazi/yazi/pull/2752