### PR TITLE
Fixed readmi rich-cli link

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Preview file types using `rich` command in Yazi. This plugin allows preview for 
 ## Requirements
 
 - [Yazi](https://github.com/sxyazi/yazi) v25.4.8 or higher.
-- [rich-cli](https://github.com/Textualize/rich) v13.7.1 or higher.
+- [rich-cli](https://github.com/Textualize/rich-cli) v13.7.1 or higher.
 
 ## Installation
 


### PR DESCRIPTION
The link in README.md for `rich-cli`  pointed to the `rich` python library instead of the CLI.
Since the actual requirement of this plugin is the cli tool, I updated the link to point to the repo of the CLI.  